### PR TITLE
Installation alternative of TimescaleDB with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ cd Databases/timescaledb
 sh install.sh
 ```
 ### Alternatively
-- You can use the `docker-compose.yaml` file to create an instance of TimescaleDB locally. 
+- You can use the `docker-compose.yaml` file to create an instance of TimescaleDB locally.
+```bash
+docker-compose up -d
+``` 
+- Yet, you still need a PostgreSQL client to interact with it.
+```bash
+sudo apt install -y postgresql-11
+``` 
+- [Commands to load data](./Database/../Databases/timescaledb/data-loading.txt) should work out of the box since the absolute path is the same in the Docker container.
 ___
 ## Dataset
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ sh install_init.sh
 cd Databases/timescaledb
 sh install.sh
 ```
+### Alternatively
+- You can use the `docker-compose.yaml` file to create an instance of TimescaleDB locally. 
 ___
 ## Dataset
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  timescaledb:
+    container_name: timescaledb # name to address the container 'e.g. docker stop timescaledb'
+    image: timescale/timescaledb:latest-pg11 # change to appropriate version
+    environment:
+      # - POSTGRES_PASSWORD=yourpassword # uncomment if you wish to use a password
+      - POSTGRES_HOST_AUTH_METHOD=trust # allow all connections without a password
+      - TS_TUNE_MAX_CONNS=200
+      - POSTGRES_USER=${USER}
+    network_mode: host # to connect from psql host client (make sure port 5432 is free)
+    volumes:
+      - "./:/home/abdel/tsdbs-lab/" # for the absolute path commands to work 
+      - "/var/run/postgresql/:/var/run/postgresql" # mounting unix socket
+
+
+


### PR DESCRIPTION
This PR adds 
- a `docker-compose.yaml` at the root of the project to be able to install TimescaleDB in Docker rather than natively and 
- instructions in the `README.md` according to this Docker alternative.